### PR TITLE
Added base command tree functionality

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,13 @@
-* Support multiple channels
+
+next steps:
+* support multiple channels (easily done by writer.join(BotConfig::channels))
+
+future stuff:
 * Adhere to this (decent standard for bots) https://supinic.com/bot/channel-bots/levels
-  * make bot command
-  * global 1 second slowmode if not VIP or mod
+  * adhere to global 1 second slowmode if not VIP or mod
   * no two messages in sequence should be same (for r9k bypass)
   * add command cooldowns (per-user)
   * permissions (per-user, persistent)
-  * debug eval custom code (LUA?) - high permission level required
   * `commands` command for printing all available commands (permission-based, e.g. a normal user won't have access to `eval`, so don't output it)
   * `help <command>` for outputting command usage info
 * More complex command parsing (same style as CLI arguments)

--- a/src/lib/bot/mod.rs
+++ b/src/lib/bot/mod.rs
@@ -106,7 +106,6 @@ fn find_command<'a>(
 
 async fn help(bot: &mut Bot, _: &messages::Privmsg<'_>, args: Option<Vec<&str>>) -> (String, bool) {
     let commands = bot.get_commands();
-    println!("ARGS: {:?}", args);
     if args.is_some() {
         if let Some((command, _)) = find_command(commands, &args.unwrap().join(" ")) {
             return (format!("{}", command.help), true);
@@ -189,7 +188,7 @@ async fn song(bot: &mut Bot, _: &messages::Privmsg<'_>, _: Option<Vec<&str>>) ->
     }
 }
 
-async fn playlist_queue(
+async fn song_queue(
     bot: &mut Bot,
     evt: &messages::Privmsg<'_>,
     args: Option<Vec<&str>>,
@@ -352,7 +351,7 @@ impl Bot {
                         commands: None,
                         data: Some(CommandData {
                             help: "FeelsDankMan Adds ~50 videos from a YouTube playlist to the StreamElements song queue. Usage: \"playlist queue <youtube playlist link>\"".into(),
-                            factory: |b,m,a| { Box::pin(playlist_queue(b,m,a))}
+                            factory: |b,m,a| { Box::pin(song_queue(b,m,a))}
                         })
                     })
                 ].into_iter().collect()),

--- a/src/lib/bot/mod.rs
+++ b/src/lib/bot/mod.rs
@@ -7,6 +7,10 @@ use twitchchat::{events, messages, Control, Dispatcher, IntoChannel, Writer};
 
 use crate::stream_elements::api::StreamElementsAPI;
 
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::future::Future;
+
 // TODO move this elsewhere
 fn duration_format(duration: chrono::Duration) -> String {
     let mut output = String::from("");
@@ -32,7 +36,137 @@ fn duration_format(duration: chrono::Duration) -> String {
 }
 
 fn strip_prefix<'a>(str: &'a str, prefix: &str) -> &'a str {
-    &str[prefix.len()..str.len()]
+    if !str.starts_with(prefix) { &str[..] }
+    else { &str[prefix.len()..str.len()] }
+}
+
+fn find_command(commands: &HashMap<String, Command>, message: &str) -> Option<CommandData> {
+    // 1. split the message by whitespace, collect into a vector
+    let tokens = message.split_whitespace().collect::<Vec<&str>>();
+    // next_commands holds the subcommands of the node we're looking at
+    let mut next_commands = commands;
+    for i in 0..tokens.len() {
+        // if we can't find the token, exit
+        if !next_commands.contains_key(tokens[i]) {
+            return None;
+        }
+        // otherwise, match what we got
+        match next_commands.get(tokens[i]).unwrap() {
+            Command::Leaf { data } => {
+                // in this case, we got a command with no subcommands,
+                // just return it 4Head
+                return Some(data.clone());
+            }
+            Command::Branch { commands, data } => {
+                // in this case, we may have gotten a command, or a subcommand
+                // first we grab the next token if we can (not out of bounds for the vector)
+                let next = if i + 1 < tokens.len() {
+                    Some(tokens[i + 1])
+                } else {
+                    None
+                };
+
+                // if there is another token, and this command has a subcommand with that name
+                if next.is_some() && commands.contains_key(next.unwrap()) {
+                    // then we set the next_commands to commands
+                    next_commands = commands;
+                    // and continue iterating
+                    continue;
+                } else {
+                    // otherwise, we check if we got any command data
+                    if data.is_none() {
+                        // if not, this is an unknown command
+                        return None;
+                    } else {
+                        // if so, this is a command, and we can return its data
+                        return Some(data.clone().unwrap());
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+async fn help(bot: &mut Bot, msg: &messages::Privmsg<'_>) -> (String, bool){
+    let commands = bot.get_commands();
+    let msg = strip_prefix(&msg.data, "xD help ");
+    if let Some(command) = find_command(commands, msg) {
+        (format!("{}", command.help), true)
+    } else {
+        let mut resp = format!("FeelsDankMan 👉 try other commands: ");
+        let keys = commands.keys().into_iter().collect::<Vec<&String>>();
+        for i in 0..keys.len() {
+            // temporarily don't display "sensitive" commands
+            if keys[i] == "stop" { continue; }
+            resp += keys[i];
+            if i+1 < keys.len() { resp += ", " }
+        }
+        (resp, true)
+    }
+}
+
+async fn ping_uptime(bot: &mut Bot, _: &messages::Privmsg<'_>) -> (String, bool) {
+    let uptime: chrono::Duration = chrono::Utc::now() - *bot.get_start();
+    (format!("FeelsDankMan uptime {}", duration_format(uptime)), true)
+}
+
+async fn ping(_: &mut Bot, _: &messages::Privmsg<'_>) -> (String, bool) {
+    (format!("FeelsDankMan 👍 Pong!"), true)
+}
+
+async fn whoami(bot: &mut Bot, msg: &messages::Privmsg<'_>) -> (String, bool) {
+    match bot.get_streamelements_api().channels().channel_id(&*msg.name).await {
+        Ok(id) => (format!("monkaHmm your id is {}", id), true),
+        Err(e) => {
+            error!(
+                "Failed to fetch the channel id for the username {:?}: {}",
+                &msg.name, e
+            );
+            (format!("WAYTOODANK devs broke something"), true)
+        }
+    }
+}
+
+async fn stop(_: &mut Bot, msg: &messages::Privmsg<'_>) -> (String, bool) {
+    if &*msg.name == "moscowwbish" {
+        return (String::new(), false);
+    }
+
+    return (String::new(), true);
+}
+
+async fn song(bot: &mut Bot, _: &messages::Privmsg<'_>) -> (String, bool) {
+    match bot.get_streamelements_api().song_requests().current_song_title().await {
+        Ok(song) => (format!("CheemJam currently playing song is {}", song), true),
+        Err(e) => {
+            error!("Failed to fetch the current song title {}", e);
+            (format!("WAYTOODANK devs broke something"), true)
+        }
+    }
+}
+
+type ResponseFactory = for<'a> fn(&'a mut Bot, &'a messages::Privmsg) -> Pin<Box<dyn Future<Output = (String, bool)> + 'a>>;
+
+#[derive(Clone)]
+pub struct CommandData {
+
+    /// Contains info about command usage
+    help: String,
+    /// Pointer to function with command logic
+    /// This should eventually be replaced by a script
+    factory: ResponseFactory,
+}
+
+pub enum Command {
+    Leaf {
+        data: CommandData,
+    },
+    Branch {
+        commands: HashMap<String, Command>,
+        data: Option<CommandData>,
+    },
 }
 
 pub struct Bot {
@@ -41,16 +175,72 @@ pub struct Bot {
     control: Control,
     config: config::BotConfig,
     start: chrono::DateTime<chrono::Utc>,
+
+    commands: HashMap<String, Command>,
 }
 
 impl Bot {
     pub fn new(api: StreamElementsAPI, writer: Writer, control: Control) -> Bot {
+        /* command tree:
+            xD
+            |__<empty>
+            |__help
+            |__ping
+            |  |__uptime
+            |__whoami
+            |__stop
+            |__song
+        */
+
+        let commands: HashMap<String, Command> = vec![
+            ("help".into(), Command::Leaf {
+                data: CommandData {
+                    help: "good one 4Head".into(),
+                    factory: |b,m| { Box::pin(help(b,m)) },
+                },
+            }),
+            ("ping".into(), Command::Branch {
+                commands: vec![
+                    ("uptime".into(),
+                    Command::Leaf {
+                        data: CommandData {
+                            help: "Outputs the bot uptime".into(),
+                            factory: |b,m| { Box::pin(ping_uptime(b,m)) },
+                        },
+                    })
+                ].into_iter().collect(),
+                data: Some(CommandData {
+                    help: "Pong!".into(),
+                    factory: |b,m| { Box::pin(ping(b,m)) },
+                }),
+            }),
+            ("whoami".into(), Command::Leaf {
+                data: CommandData {
+                    help: "monkaS Returns your StreamElements account id".into(),
+                    factory: |b,m| { Box::pin(whoami(b,m)) }
+                }
+            }),
+            ("stop".into(), Command::Leaf {
+                data: CommandData {
+                    help: "Stops the bot".into(),
+                    factory: |b,m| { Box::pin(stop(b,m)) }
+                }
+            }),
+            ("song".into(), Command::Leaf {
+                data: CommandData {
+                    help: "Shows the currently playing song".into(),
+                    factory: |b,m| { Box::pin(song(b,m)) }
+                }
+            })
+        ].into_iter().collect();
+
         Bot {
             api,
             writer,
             control,
             config: BotConfig::get(),
             start: chrono::Utc::now(),
+            commands,
         }
     }
 
@@ -80,61 +270,46 @@ impl Bot {
         }
     }
 
+    pub fn get_streamelements_api(&mut self) -> &StreamElementsAPI {
+        &self.api
+    }
+    pub fn get_writer(&mut self) -> &Writer {
+        &self.writer
+    }
+    pub fn get_config(&mut self) -> &BotConfig {
+        &self.config
+    }
+    pub fn get_start(&mut self) -> &chrono::DateTime<chrono::Utc> {
+        &self.start
+    }
+    pub fn get_commands(&mut self) -> &HashMap<String, Command> {
+        &self.commands
+    }
+
     async fn handle_msg(&mut self, evt: &messages::Privmsg<'_>) -> bool {
-        match &*evt.data {
-            cmd @ "xD" => {
-                info!("command {:?} in channel {}", cmd, &evt.channel);
-                let resp = format!("xD");
-                self.writer.privmsg(&evt.channel, &resp).await.unwrap();
-            }
-            cmd @ "xD ping" => {
-                info!("command {:?} in channel {}", cmd, &evt.channel);
+        if !evt.data.starts_with("xD") {
+            return true;
+        }
 
-                let uptime: chrono::Duration = chrono::Utc::now() - self.start;
-                let resp = format!("FeelsDankMan uptime {}", duration_format(uptime));
-                self.writer.privmsg(&evt.channel, &resp).await.unwrap();
-            }
-            cmd @ "xD whoami" => {
-                info!("command {:?} in channel {}", cmd, &evt.channel);
-                let resp = match self.api.channels().channel_id(&*evt.name).await {
-                    Ok(id) => format!("monkaHmm your id is {}", id),
-                    Err(e) => {
-                        error!(
-                            "Failed to fetch the channel id for the username {:?}: {}",
-                            &evt.name, e
-                        );
-                        format!("WAYTOODANK devs broke something")
-                    }
-                };
-                self.writer.privmsg(&evt.channel, &resp).await.unwrap();
-            }
-            cmd @ "xD song" => {
-                info!("command {:?} in channel {}", cmd, &evt.channel);
-                let resp = match self.api.song_requests().current_song_title().await {
-                    Ok(song) => format!("CheemJam currently playing song is {}", song),
-                    Err(e) => {
-                        error!("Failed to fetch the current song title {}", e);
-                        format!("WAYTOODANK devs broke something")
-                    }
-                };
-                self.writer.privmsg(&evt.channel, &resp).await.unwrap();
-            }
-            cmd @ "xD stop" => {
-                if &*evt.name == "moscowwbish" {
-                    info!("command {:?} in channel {}", cmd, &evt.channel);
-                    self.control.stop();
-                    return false;
-                }
-            }
-            rest if rest.starts_with("xD") => {
-                info!("unknown command {:?} in channel {}", rest, &evt.channel);
-                let rest = strip_prefix(rest, "xD ");
-                let resp = format!("WAYTOODANK 👉 UNKNOWN COMMAND \"{}\"", rest);
-                self.writer.privmsg(&evt.channel, &resp).await.unwrap();
-            }
-            _ => { /* not a command, just ignore 4Head */ }
-        };
+        // hardcoded "xD" response because it needs to exist
+        if evt.data.trim() == "xD" {
+            self.writer.privmsg(&evt.channel, "xD").await.unwrap();
+            return true;
+        }
 
-        true
+        let message = strip_prefix(&evt.data, "xD ");
+        if let Some(command) = find_command(&self.commands, message) {
+            let (response, continue_running) = (command.factory)(self, evt).await;
+            if !continue_running {
+                self.control.stop();
+                return false;
+            } else {
+                self.writer.privmsg(&evt.channel, &response).await.unwrap();
+                return true;
+            }
+        } else {
+            self.writer.privmsg(&evt.channel, "WAYTOODANK 👉 Unknown command!").await.unwrap();
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Commands are stored as a `HashMap<String, Command>`

A `command` is currently composed of:  
* a list of sub`command`s
* help information (usage or output)
* a pointer to a *response factory*

In the future, we could additionally include metadata such as required user permissions, cooldown, which channels the command applies in (for channel-specific custom commands), etc.

*Response factories* are free async functions with the signature:  
```rust
async fn(bot: &mut Bot, message: &twitchchat::messages::Privmsg) -> (String, bool)
```
This should also eventually change, because as it stands, each command is receiving the whole user message including the prefix, which is not ideal. We should also not be exposing the bot directly, but some kind of middle-man, something along the lines of `CommandUtils` or `CommandAPI`.

Currently, the setup is pretty janky, requiring the actual response factory to be wrapped in a closure which pins the returned future. This should no longer be a problem once we're using LUA scripts as "response factories" instead of free functions. As a result, the temporarily hardcoded command tree initialization is pretty ugly. Again, once it's replaced by a JSON file, it won't be a problem.
